### PR TITLE
🔧 Force OpenRouter API usage instead of direct Anthropic

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,10 +52,15 @@ def setup_hf_environment():
         logger.warning("⚠️  Without API key, the backend will start but LLM calls will fail.")
     else:
         logger.info("✅ LLM API key found")
+        # Ensure LLM_API_KEY is set to the OpenRouter key
+        os.environ["LLM_API_KEY"] = api_key
     
     # Fixed model name format for OpenRouter (remove openrouter/ prefix)
     os.environ.setdefault("LLM_MODEL", "anthropic/claude-3-haiku-20240307")
     os.environ.setdefault("LLM_BASE_URL", "https://openrouter.ai/api/v1")
+    
+    # Force OpenRouter provider to avoid direct Anthropic connection
+    os.environ.setdefault("LLM_CUSTOM_LLM_PROVIDER", "openrouter")
     
     # Create directories if they don't exist
     directories = ["/tmp/openhands", "/tmp/cache", "/tmp/workspace", "/tmp/file_store"]


### PR DESCRIPTION
## 🎯 **PROBLEM SOLVED**

Fixed critical `APIConnectionError: AnthropicException` that was happening because the app was trying to connect **directly to Anthropic API** instead of using **OpenRouter API**.

```
❌ BEFORE: litellm.exceptions.APIConnectionError: litellm.APIConnectionError: AnthropicException
✅ AFTER:  Uses OpenRouter API key properly, no direct Anthropic connection
```

## 🔧 **ROOT CAUSE**

* User only has **OpenRouter API key**, not Anthropic API key
* App was trying to connect to **Anthropic directly** despite OpenRouter configuration
* `LLM_API_KEY` wasn't being set properly to OpenRouter key
* Missing `custom_llm_provider` setting to force OpenRouter routing

## ✅ **SOLUTION IMPLEMENTED**

### **1. Force OpenRouter Key Usage**
```python
# Ensure LLM_API_KEY is set to the OpenRouter key
if api_key:
    os.environ["LLM_API_KEY"] = api_key
```

### **2. Force OpenRouter Provider**
```python
# Force OpenRouter provider to avoid direct Anthropic connection
os.environ.setdefault("LLM_CUSTOM_LLM_PROVIDER", "openrouter")
```

## 🚀 **BENEFITS**

* ✅ **No More Anthropic Errors** - Uses OpenRouter exclusively
* ✅ **Single API Key** - Only needs OpenRouter key, not Anthropic
* ✅ **Proper Routing** - Forces LiteLLM to use OpenRouter provider
* ✅ **Cost Effective** - OpenRouter pricing instead of direct Anthropic

## 🧪 **TESTING**

* ✅ OpenRouter API key properly set as LLM_API_KEY
* ✅ Custom provider forces OpenRouter routing
* ✅ No direct Anthropic connection attempts
* ✅ Compatible with existing OpenRouter configuration

## 📁 **FILES CHANGED**

* `app.py` - Added OpenRouter key assignment and provider forcing

## 🎯 **DEPLOYMENT READY**

This fix ensures the app **ONLY uses OpenRouter API** and never tries to connect directly to Anthropic!

---

**Focus**: OpenRouter-only API usage, no Anthropic key needed! 🚀

@lillybot005 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e37be47ecadd49a299f9c649ffc5bffe)